### PR TITLE
Bug/iam creds

### DIFF
--- a/rosa-content/500-service-mesh/deploy-control-plane.md
+++ b/rosa-content/500-service-mesh/deploy-control-plane.md
@@ -22,6 +22,9 @@ Based on the open source Istio project, Red Hat OpenShift Service Mesh adds a tr
       namespace: istio-system
     spec:
       version: v2.2
+      security:
+        identity:
+          type: ThirdParty  #required setting for ROSA
       tracing:
         type: Jaeger
         sampling: 10000
@@ -37,7 +40,6 @@ Based on the open source Istio project, Red Hat OpenShift Service Mesh adds a tr
         grafana:
           enabled: true
     ```
-
 
 1. Run the following command to deploy the Service Mesh control plane.
 

--- a/rosa-content/assets/istio_installation.yaml
+++ b/rosa-content/assets/istio_installation.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: istio-system
 spec:
   version: v2.2
+  security:
+    identity:
+      type: ThirdParty  #required setting for ROSA
   tracing:
     type: Jaeger
     sampling: 10000


### PR DESCRIPTION
A couple of the bigger fixes needed from the first go-around:

1. Instead of pushing IAM creds to Github, we create a `Secret` beforehand and then tell Quarkus to map it into the Microsweeper Pods as environment variables
2. Quarkus now creates a `Deployment` instead of a `DeploymentConfig`, so the built experience aligns with the docs and screenshots
3. The Istio SMCP definition is updated in the docs and the assets so it includes the necessary `security` key to make it work on ROSA